### PR TITLE
Fade-out sound players even when idle or buffering

### DIFF
--- a/app/src/test/java/com/github/ashutoshgngwr/noice/engine/LocalSoundPlayerTest.kt
+++ b/app/src/test/java/com/github/ashutoshgngwr/noice/engine/LocalSoundPlayerTest.kt
@@ -290,7 +290,7 @@ class LocalSoundPlayerTest {
       TestCase(
         mediaPlayerState = MediaPlayer.State.BUFFERING,
         pauseImmediate = false,
-        isExpectingFadeTransition = false,
+        isExpectingFadeTransition = true,
       ),
       TestCase(
         mediaPlayerState = MediaPlayer.State.BUFFERING,
@@ -319,7 +319,6 @@ class LocalSoundPlayerTest {
       soundPlayer.pause(testCase.pauseImmediate)
       if (testCase.isExpectingFadeTransition) {
         assertEquals(SoundPlayer.State.PAUSING, soundPlayer.state)
-        assertEquals(1F, fakeMediaPlayer.pendingFadeTransition?.fromVolume)
         assertEquals(0F, fakeMediaPlayer.pendingFadeTransition?.toVolume)
         fakeMediaPlayer.consumePendingFadeTransition()
       }
@@ -340,7 +339,7 @@ class LocalSoundPlayerTest {
       TestCase(
         mediaPlayerState = MediaPlayer.State.BUFFERING,
         stopImmediate = false,
-        isExpectingFadeTransition = false,
+        isExpectingFadeTransition = true,
       ),
       TestCase(
         mediaPlayerState = MediaPlayer.State.BUFFERING,
@@ -369,7 +368,6 @@ class LocalSoundPlayerTest {
       soundPlayer.stop(testCase.stopImmediate)
       if (testCase.isExpectingFadeTransition) {
         assertEquals(SoundPlayer.State.STOPPING, soundPlayer.state)
-        assertEquals(1F, fakeMediaPlayer.pendingFadeTransition?.fromVolume)
         assertEquals(0F, fakeMediaPlayer.pendingFadeTransition?.toVolume)
         fakeMediaPlayer.consumePendingFadeTransition()
       }


### PR DESCRIPTION
This helps maintain behaviour parity among contiguous and non-contiguous sounds. In the current implementation, non-contiguous sounds stop immediately when the underlying media player is idle. It results in an incorrect preset state during `SoundPlayerManager`'s `PAUSING` and `STOPPING` transitions.

resolves #1155